### PR TITLE
remove whitespace from JWT_SECRET

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: akhilrex/hammond
     container_name: hammond
     environment:
-      - JWT_SECRET = somethingverystrong
+      - JWT_SECRET=somethingverystrong
     volumes:
       - /path/to/config:/config
       - /path/to/data:/assets


### PR DESCRIPTION
When deploying with the whitespace around the `=`, docker complains.