### PR TITLE
Add vscode specific files to gitignore

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -12,6 +12,10 @@
 *.out
 *.db
 
+# MS VSCode
+.vscode
+__debug_bin
+
 # Dependency directories (remove the comment below to include it)
 # vendor/
 assets/*


### PR DESCRIPTION
When debugging the `go` code in vscode it creates an object named `__debug_bin`. This should be ignored by git