### PR TITLE
Run Github actions on releases

### DIFF
--- a/.github/workflows/hub.yml
+++ b/.github/workflows/hub.yml
@@ -1,8 +1,8 @@
-name: ci
+name: Build docker image
 
 on:
-  push:
-    branches: master
+  release:
+    types: [published]
 
 jobs:
   multi:
@@ -26,6 +26,9 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
+      - name: Parse the git tag
+        id: get_tag
+        run: echo ::set-output name=TAG::$(echo $GITHUB_REF | cut -d / -f 3)
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
@@ -50,6 +53,6 @@ jobs:
           # cache-to: type=local,dest=/tmp/.buildx-cache
           tags: |
             akhilrex/hammond:latest
-            akhilrex/hammond:1.0.0
+            akhilrex/hammond:${{ steps.get_tag.outputs.TAG }}
             ghcr.io/akhilrex/hammond:latest
-            ghcr.io/akhilrex/hammond:1.0.0
+            ghcr.io/akhilrex/hammond:${{ steps.get_tag.outputs.TAG }}

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -1,0 +1,16 @@
+on: [push, pull_request]
+name: Test server
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.17.x, 1.18.x]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/setup-go@v3
+      with:
+        go-version: ${{ matrix.go-version }}
+    - uses: actions/checkout@v3
+    - run: go test ./...
+      working-directory: server

--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -1,0 +1,22 @@
+name: Test UI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x, 15.x]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+        working-directory: ui
+      - run: npm run build --if-present
+        working-directory: ui
+      - run: npm test
+        working-directory: ui


### PR DESCRIPTION
* Run the release pipeline only on tags/releases, and use the tag on the Docker image too, instead of hard-coding `1.0.0`
* Add a simple CI pipeline on every commit to run basic go and npm tests. Please note the npm tests are currently failing, but I think this is a problem with the code rather than the pipeline.

Hope this helps improve the devops on this project :smile: 
Part of #91