### PR TITLE
update axios version - fixing quick entry upload

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -34,7 +34,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.27",
     "@fortawesome/free-solid-svg-icons": "^5.12.1",
     "@fortawesome/vue-fontawesome": "0.1.9",
-    "axios": "^0.27.0",
+    "axios": "^0.27.2",
     "buefy": "^0.9.7",
     "chart.js": "^2.9.4",
     "core-js": "3.6.4",


### PR DESCRIPTION
Hello,

I have updated the axios version from 0.27.0 to 0.27.2.
The older version had a bug which doesnt set the Content-Type correctly to multipart-form with boundary data while uploading a quick entry image.

This pull request addresses the issue #104.

BR